### PR TITLE
Add a newline after opening code blocks

### DIFF
--- a/lib/text_helpers.js
+++ b/lib/text_helpers.js
@@ -12,7 +12,7 @@ const logger = require('./logging');
 async function paginateMessage(message, textToSend) {
   const limit = 1950;
   if (textToSend.length <= limit) {
-    const sentMessage = await message.reply('```' + textToSend + '```');
+    const sentMessage = await message.reply('```\n' + textToSend + '```');
     return [sentMessage];
   }
   let split = Math.min(limit, textToSend.length);
@@ -23,7 +23,7 @@ async function paginateMessage(message, textToSend) {
     }
   }
   logger.log('debug', 'Splitting at %i', split);
-  const sentMessage = await message.reply('```' + textToSend.slice(0, Math.min(split, textToSend.length)) + '```');
+  const sentMessage = await message.reply('```\n' + textToSend.slice(0, Math.min(split, textToSend.length)) + '```');
   const subseqeuentMessages = await paginateMessage(message, textToSend.slice(split));
   return [sentMessage, ...subseqeuentMessages];
 }
@@ -39,7 +39,7 @@ function paginateMessageToFunction(sendFunction, textToSend) {
   const limit = 1950;
 
   if (textToSend.length <= limit) {
-    sendFunction('```' + textToSend + '```');
+    sendFunction('```\n' + textToSend + '```');
     return;
   }
   let split = Math.min(limit, textToSend.length);
@@ -50,7 +50,7 @@ function paginateMessageToFunction(sendFunction, textToSend) {
     }
   }
   logger.log('debug', 'Splitting at %i', split);
-  sendFunction('```' + textToSend.slice(0, Math.min(split, textToSend.length)) + '```');
+  sendFunction('```\n' + textToSend.slice(0, Math.min(split, textToSend.length)) + '```');
   paginateMessageToFunction(sendFunction, textToSend.slice(split));
 }
 


### PR DESCRIPTION
Discord apparently is now finicky about what goes on the first line of a code block, so adding a newline whenever we open one should alleviate the issue of the first line of output disappearing.

Most things go via the text helper in the associated first commit, though I'm yet to do a pass through to check if there are any other explicit sends.